### PR TITLE
Independently configurable resource locale setting

### DIFF
--- a/config/arbory.php
+++ b/config/arbory.php
@@ -4,6 +4,17 @@ return [
     'title' => 'Arbory',
     'uri' => 'admin',
 
+    /**
+     * Locale to use in CMS
+     */
+    // 'locale' => 'en',
+
+    /**
+     * Locale to use for resource translations in CMS. null value will use CMS
+     * default locale or application default locale.
+     */
+    //'resource_locale' => 'en',
+
     'locales' => [
         'en',
     ],

--- a/src/Http/Middleware/ArborySetLocaleMiddleware.php
+++ b/src/Http/Middleware/ArborySetLocaleMiddleware.php
@@ -5,6 +5,7 @@ namespace Arbory\Base\Http\Middleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Closure;
+use Illuminate\Config\Repository as ConfigurationRepository;
 
 class ArborySetLocaleMiddleware
 {
@@ -14,12 +15,21 @@ class ArborySetLocaleMiddleware
     private $app;
 
     /**
+     * @var ConfigurationRepository
+     */
+    private $config;
+
+    /**
      * ArborySetLocaleMiddleware constructor.
      * @param Application $app
+     * @param ConfigurationRepository $configurationRepository
      */
-    public function __construct(Application $app)
-    {
+    public function __construct(
+        Application $app,
+        ConfigurationRepository $configurationRepository
+    ) {
         $this->app = $app;
+        $this->config = $configurationRepository;
     }
 
     /**
@@ -32,6 +42,11 @@ class ArborySetLocaleMiddleware
         $this->app->setLocale($this->defaultLocale());
         $request->setLocale($this->defaultLocale());
 
+        $resourceLocale = $this->config->get('arbory.resource_locale');
+        if ($resourceLocale) {
+            $this->config->set('translatable.locale', $resourceLocale);
+        }
+
         return $next($request);
     }
 
@@ -40,6 +55,6 @@ class ArborySetLocaleMiddleware
      */
     private function defaultLocale(): string
     {
-        return config('arbory.locale') ?: config('app.locale');
+        return $this->config->get('arbory.locale') ?: $this->config->get('app.locale');
     }
 }


### PR DESCRIPTION
A separate setting for resource locale. Enabled on the admin route namespace. If not configured, uses the same logic as before.